### PR TITLE
Fix not being able to compile with default features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ use std::ops::Deref;
 pub mod macros;
 
 pub mod tag;
-use help::DocParams;
 use tag::Full;
 
 mod error;
@@ -24,6 +23,8 @@ pub use error::ArgParseError;
 
 #[cfg(feature = "help")]
 mod help;
+#[cfg(feature = "help")]
+use help::DocParams;
 
 mod types;
 pub use types::{ArgResult, ArgumentType, DefaultedArgResult};

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -70,6 +70,7 @@ impl Full {
     ///
     /// Only available on feature `help`.
     #[must_use]
+    #[cfg(feature = "help")]
     pub fn doc<S: ToString>(mut self, doc: S) -> Self {
         let doc = doc.to_string();
         if doc.is_empty() {


### PR DESCRIPTION
Currently, the `doc` function states in it's doc comments that it is only available on feature "help," however this is not enforced by a `cfg(feature="help")` attribute. This pull request fixes that, as well as a missing feature attribute gating a `use help` in lib.rs