### PR TITLE
Support repeatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ sarge! {
     // Here's every feature in one argument: a `Result<T, _>` that can be set
     // via `-b`, `--baz`, or `BAZ=`, and defaults to [1, 2, 3] if not passed.
     #err 'b' @BAZ baz: Vec<u64> = vec![1, 2, 3],
+
+    // Convenience: for `Vec<String>`, you can write `vec!["a", "b"]` as a default
+    // (elements are converted to `String` automatically).
 }
 
 // Some utility macros to make this example less verbose.

--- a/README.md
+++ b/README.md
@@ -86,11 +86,14 @@ disable the `macros` feature, this won't compile:
 ```rust
 use sarge::prelude::*;
 
+// Use Rust doc comments (`/// ...`) inside `sarge!` to provide help text.
+// (The legacy `> "..."` doc syntax has been removed.)
+
 // This is a normal, non-proc macro. That means sarge is still
 // zero-dependency! The syntax may seem a little strange at first, but it
 // should help greatly when defining your CLI interface.
 sarge! {
-    // This is the name of our struct.
+    /// Documentation shown in `Args::help()` (feature `help`).
     Args,
 
     // These are our arguments. Each will have a long variant matching the
@@ -102,7 +105,8 @@ sarge! {
     // will panic. Thankfully, `bool` arguments are immune to both, and
     // `String` arguments are immune to the latter.
 
-    first: bool, // true if `--first` is passed, false otherwise
+    /// true if `--first` is passed, false otherwise
+    first: bool,
 
     // If you want a short variant (e.g. '-s'), you can specify one with a char
     // literal before the name (but after the wrapper, if any):

--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ sarge! {
     // via `-b`, `--baz`, or `BAZ=`, and defaults to [1, 2, 3] if not passed.
     #err 'b' @BAZ baz: Vec<u64> = vec![1, 2, 3],
 
+    // `Vec<T>` arguments can also be repeated; values are appended:
+    // `--baz 1 --baz 2` is equivalent to `--baz 1,2`.
+
     // Convenience: for `Vec<String>`, you can write `vec!["a", "b"]` as a default
     // (elements are converted to `String` automatically).
 }

--- a/examples/macros.rs
+++ b/examples/macros.rs
@@ -1,17 +1,17 @@
 use sarge::prelude::*;
 
 sarge! {
-    > "This is a basic macros example."
+    /// This is a basic macros example.
     Args,
 
-    > "Show this help message."
+    /// Show this help message.
     'h' help: bool,
 
-    > "The name to greet."
+    /// The name to greet.
     'n' @NAME name: String,
 
-    > "The number of times to greet."
-    > "Defaults to 1."
+    /// The number of times to greet.
+    /// Defaults to 1.
     #ok times: u32,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,11 @@ where
     d.__sarge_default()
 }
 
-/// Like [`__sarge_default`], but intentionally does *not* include literal-only
-/// convenience conversions (such as `&str -> String`) to avoid type inference
-/// ambiguity for expression defaults like `"foo".into()`.
+/// A helper trait for expression defaults in `sarge!`.
+///
+/// This is intentionally narrower than `__SargeDefault`: it avoids adding
+/// `&str -> String` for all expressions, which can otherwise trigger type
+/// inference ambiguity for defaults like `"foo".into()`.
 #[doc(hidden)]
 pub trait __SargeDefaultExpr<T> {
     fn __sarge_default_expr(self) -> T;
@@ -75,10 +77,7 @@ impl<'a> __SargeDefaultExpr<Vec<String>> for Vec<&'a str> {
 }
 
 #[doc(hidden)]
-pub fn __sarge_default_expr<T, D>(d: D) -> T
-where
-    D: __SargeDefaultExpr<T>,
-{
+pub fn __sarge_default_expr<T>(d: impl __SargeDefaultExpr<T>) -> T {
     d.__sarge_default_expr()
 }
 
@@ -90,6 +89,8 @@ mod test;
 struct InternalArgument {
     tag: Full,
     consumes: bool,
+    repeatable: bool,
+    cli_set: bool,
     val: Option<Option<String>>,
 }
 
@@ -175,11 +176,11 @@ impl<T: ArgumentType> ArgumentRef<T> {
     /// (`#ok`/`#err`) and macro-provided defaults to take precedence.
     #[doc(hidden)]
     pub fn get_raw(&self, args: &Arguments) -> ArgResult<T> {
-        args.get_arg(self.i)
-            .val
-            .as_ref()
-            .map(|val| T::from_value(val.as_deref()))
-            .flatten()
+        if let Some(val) = &args.get_arg(self.i).val {
+            T::from_value(val.as_deref())
+        } else {
+            None
+        }
     }
 
     /// Retrieve the tag of the argument from an [`Arguments`].
@@ -274,6 +275,8 @@ impl ArgumentReader {
         let arg = InternalArgument {
             tag,
             consumes: T::CONSUMES,
+            repeatable: T::REPEATABLE,
+            cli_set: false,
             val: None,
         };
 
@@ -377,6 +380,11 @@ impl ArgumentReader {
                     .find(|arg| arg.tag.matches_long(long))
                     .ok_or(ArgParseError::UnknownFlag(long.to_string()))?;
 
+                if !arg.cli_set {
+                    arg.val = None;
+                    arg.cli_set = true;
+                }
+
                 let val = if arg.consumes {
                     if val.is_none() {
                         args.next().map(tostring)
@@ -387,7 +395,21 @@ impl ArgumentReader {
                     None
                 };
 
-                arg.val = Some(val);
+                if arg.repeatable {
+                    if let Some(val) = val {
+                        match &mut arg.val {
+                            Some(Some(existing)) => {
+                                existing.push(',');
+                                existing.push_str(&val);
+                            }
+                            _ => {
+                                arg.val = Some(Some(val));
+                            }
+                        }
+                    }
+                } else {
+                    arg.val = Some(val);
+                }
             } else if let Some(shorts) = arg.strip_prefix('-') {
                 if shorts.is_empty() {
                     remainder.push(String::from("-"));
@@ -411,7 +433,26 @@ impl ArgumentReader {
                             None
                         };
 
-                        arg.val = Some(next);
+                        if !arg.cli_set {
+                            arg.val = None;
+                            arg.cli_set = true;
+                        }
+
+                        if arg.repeatable {
+                            if let Some(next) = next {
+                                match &mut arg.val {
+                                    Some(Some(existing)) => {
+                                        existing.push(',');
+                                        existing.push_str(&next);
+                                    }
+                                    _ => {
+                                        arg.val = Some(Some(next));
+                                    }
+                                }
+                            }
+                        } else {
+                            arg.val = Some(next);
+                        }
                     }
                 }
             } else {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -233,10 +233,9 @@ macro_rules! __var_tag {
 ///     page: u32 = 1,
 /// ```
 ///
-/// This example shows an infallible default, i.e. even if the argument is
-/// passed but fails to parse, it will be defaulted. You may instead desire to
-/// place the default on an `#err` argument, in which case it will become
-/// `Result<T, _>`.
+/// Defaults apply when an argument is missing. If the argument is provided but
+/// fails to parse, wrapper semantics still apply (`#ok` becomes `None`, `#err`
+/// becomes `Err(_)`, and no wrapper will panic).
 ///
 /// You may place defaults on `#ok` arguments by providing a plain value.
 /// This will be wrapped in `Some(...)` internally and used when the argument

--- a/src/test.rs
+++ b/src/test.rs
@@ -132,6 +132,44 @@ fn int_list_type() {
 }
 
 #[test]
+fn repeatable_list_type_accumulates_values() {
+    let mut parser = ArgumentReader::new();
+    let list = parser.add(tag::short('H'));
+
+    let args = ["test", "-H", "xx", "-H", "xxx", "-H", "sadfh,sjffk"];
+
+    let args = parser.parse_cli(args).expect("failed to parse arguments");
+
+    assert_eq!(
+        list.get(&args),
+        Some(Ok(vec![
+            "xx".to_string(),
+            "xxx".to_string(),
+            "sadfh".to_string(),
+            "sjffk".to_string(),
+        ]))
+    );
+}
+
+#[test]
+fn repeatable_list_type_cli_overrides_env() {
+    let mut parser = ArgumentReader::new();
+    let list = parser.add(tag::long("list").env("LIST"));
+
+    let env = [("LIST", "env1,env2")];
+    let cli = ["test", "--list", "cli1", "--list", "cli2"];
+
+    let args = parser
+        .parse_provided(cli, env)
+        .expect("failed to parse provided arguments");
+
+    assert_eq!(
+        list.get(&args),
+        Some(Ok(vec!["cli1".to_string(), "cli2".to_string()]))
+    );
+}
+
+#[test]
 fn basic_env_var() {
     let mut parser = ArgumentReader::new();
     let cfg = parser.add(tag::env("CONFIG_DIR"));

--- a/src/test/macros.rs
+++ b/src/test/macros.rs
@@ -107,11 +107,14 @@ sarge! {
     // `#ok` default is a plain value; macro wraps it in `Some(...)`.
     #ok 't' target_addr: String = "127.0.0.1:9911",
 
-    // `#ok` default should be used when parsing fails.
+    // `#ok + default` applies only to missing values; parse failures become `None`.
     #ok 'n' num: u32 = 42,
 
     // `#err` default is a plain value (not `Some(Ok(...))`).
-    #err 'h' help: bool = false,
+    #err 'h' help: bool = true,
+
+    // `Vec<String>` defaults can be specified without `.into()` per element.
+    #ok 'd' data: Vec<String> = vec![r#"{"name":"hello"}"#],
 }
 
 #[test]
@@ -122,7 +125,8 @@ fn defaults_are_applied() {
     assert_eq!(args.socket_addr, "127.0.0.1:9912");
     assert_eq!(args.target_addr.as_deref(), Some("127.0.0.1:9911"));
     assert_eq!(args.num, Some(42));
-    assert_eq!(args.help, Ok(false));
+    assert_eq!(args.help, Ok(true));
+    assert_eq!(args.data, Some(vec![r#"{"name":"hello"}"#.to_string()]));
 }
 
 #[test]

--- a/src/test/macros.rs
+++ b/src/test/macros.rs
@@ -22,7 +22,7 @@ sarge! {
     // of the argument, i.e. `-f`
     'f' fourth: f64,
 
-    // You can give values an infallible default:
+    // You can give values a default:
     fifth: u32 = 1,
 
     // ...or keep any errors:
@@ -93,6 +93,36 @@ fn doc_comments_are_used_for_help() {
     assert!(s.contains("DocComment test flag"));
 }
 
+#[cfg(feature = "help")]
+#[test]
+fn angle_docs_are_used_for_help() {
+    let s = DerivedArgs::help();
+    assert!(s.contains("Derived test args"));
+    assert!(s.contains("Derived test flag"));
+}
+
+#[cfg(feature = "help")]
+sarge! {
+    > "Docs from >"
+    /// Docs from ///
+    #[allow(dead_code)]
+    MixedDocArgs,
+
+    > "Field docs from >"
+    /// Field docs from ///
+    mixed_flag: bool,
+}
+
+#[cfg(feature = "help")]
+#[test]
+fn mixed_docs_are_used_for_help() {
+    let s = MixedDocArgs::help();
+    assert!(s.contains("Docs from >"));
+    assert!(s.contains("Docs from ///"));
+    assert!(s.contains("Field docs from >"));
+    assert!(s.contains("Field docs from ///"));
+}
+
 mod polluted_ok_import {
     use super::anyhow;
     use crate::prelude::*;
@@ -141,6 +171,44 @@ sarge! {
     #ok 'H' headers: Vec<String>,
 }
 
+#[cfg(feature = "macros")]
+sarge! {
+    RepeatableVecEnvArgs,
+    #ok @HEADERS headers: Vec<String>,
+}
+
+// Test matrix: wrapper type (none/#ok/#err) × default (none/some) × input
+// (missing/parse ok/parse err).
+sarge! {
+    #[derive(Debug, PartialEq, Eq)]
+    OkNoDefaultArgs,
+    #ok ok_num: u32,
+}
+
+sarge! {
+    #[derive(Debug, PartialEq, Eq)]
+    ErrNoDefaultArgs,
+    #err err_num: u32,
+}
+
+sarge! {
+    #[derive(Debug, PartialEq, Eq)]
+    ErrDefaultArgs,
+    #err err_num: u32 = 9,
+}
+
+sarge! {
+    #[derive(Debug, PartialEq, Eq)]
+    PlainNoDefaultArgs,
+    num: u32,
+}
+
+sarge! {
+    #[derive(Debug, PartialEq, Eq)]
+    PlainDefaultArgs,
+    num: u32 = 7,
+}
+
 #[test]
 fn defaults_are_applied() {
     let (args, remainder) = DefaultArgs::parse_cli(["bin"]).expect("failed to parse default args");
@@ -179,6 +247,34 @@ fn repeatable_vec_type_accumulates_in_macro() {
 }
 
 #[test]
+fn repeatable_vec_type_accumulates_in_macro_with_long_form() {
+    let (args, remainder) =
+        RepeatableVecArgs::parse_cli(["bin", "--headers", "a", "--headers", "b,c"])
+            .expect("failed to parse repeatable vec args");
+
+    assert_eq!(remainder, vec!["bin"]);
+    assert_eq!(
+        args.headers,
+        Some(vec!["a".to_string(), "b".to_string(), "c".to_string(),])
+    );
+}
+
+#[test]
+fn repeatable_vec_type_cli_overrides_env_in_macro() {
+    let env = [("HEADERS", "env1,env2")];
+    let cli = ["bin", "--headers", "cli1", "--headers", "cli2"];
+
+    let (args, remainder) = RepeatableVecEnvArgs::parse_provided(cli, env)
+        .expect("failed to parse repeatable vec args");
+
+    assert_eq!(remainder, vec!["bin"]);
+    assert_eq!(
+        args.headers,
+        Some(vec!["cli1".to_string(), "cli2".to_string()])
+    );
+}
+
+#[test]
 fn ok_default_is_none_on_parse_error() {
     let (args, _) = DefaultArgs::parse_cli(["bin", "--num", "not-a-number"])
         .expect("parse_cli should succeed; #ok turns parse failures into None");
@@ -201,4 +297,116 @@ fn ok_default_does_not_default_on_parse_error() {
         .expect("parse_cli should succeed; #ok turns parse failures into None");
 
     assert_eq!(args.num, None);
+}
+
+#[test]
+fn ok_without_default_missing_is_none() {
+    let (args, _) = OkNoDefaultArgs::parse_cli(["bin"]).expect("failed to parse ok args");
+    assert_eq!(args.ok_num, None);
+}
+
+#[test]
+fn ok_without_default_parse_success_is_some() {
+    let (args, _) =
+        OkNoDefaultArgs::parse_cli(["bin", "--ok-num", "123"]).expect("failed to parse ok args");
+    assert_eq!(args.ok_num, Some(123));
+}
+
+#[test]
+fn ok_without_default_parse_failure_is_none() {
+    let (args, _) =
+        OkNoDefaultArgs::parse_cli(["bin", "--ok-num", "bad"]).expect("failed to parse ok args");
+    assert_eq!(args.ok_num, None);
+}
+
+#[test]
+fn ok_default_parse_success_overrides_default() {
+    let (args, _) =
+        DefaultArgs::parse_cli(["bin", "--num", "7"]).expect("failed to parse default args");
+    assert_eq!(args.num, Some(7));
+}
+
+#[test]
+fn ok_default_string_overrides_default() {
+    let (args, _) = DefaultArgs::parse_cli(["bin", "--target-addr", "x"])
+        .expect("failed to parse default args");
+    assert_eq!(args.target_addr.as_deref(), Some("x"));
+}
+
+#[test]
+fn err_without_default_missing_is_none() {
+    let (args, _) = ErrNoDefaultArgs::parse_cli(["bin"]).expect("failed to parse err args");
+    assert_eq!(args.err_num, None);
+}
+
+#[test]
+fn err_without_default_parse_success_is_ok() {
+    let (args, _) =
+        ErrNoDefaultArgs::parse_cli(["bin", "--err-num", "123"]).expect("failed to parse err args");
+    assert_eq!(args.err_num, Some(Ok(123)));
+}
+
+#[test]
+fn err_without_default_parse_failure_is_err() {
+    let (args, _) =
+        ErrNoDefaultArgs::parse_cli(["bin", "--err-num", "bad"]).expect("failed to parse err args");
+    assert!(matches!(args.err_num, Some(Err(_))));
+}
+
+#[test]
+fn err_default_missing_uses_default() {
+    let (args, _) = ErrDefaultArgs::parse_cli(["bin"]).expect("failed to parse err default args");
+    assert_eq!(args.err_num, Ok(9));
+}
+
+#[test]
+fn err_default_parse_success_overrides_default() {
+    let (args, _) =
+        ErrDefaultArgs::parse_cli(["bin", "--err-num", "10"]).expect("failed to parse err args");
+    assert_eq!(args.err_num, Ok(10));
+}
+
+#[test]
+fn err_default_parse_failure_is_err() {
+    let (args, _) =
+        ErrDefaultArgs::parse_cli(["bin", "--err-num", "bad"]).expect("failed to parse err args");
+    assert!(args.err_num.is_err());
+}
+
+#[test]
+#[should_panic(expected = "Tried to unwrap argument that wasn't passed")]
+fn plain_without_default_missing_panics() {
+    let _ = PlainNoDefaultArgs::parse_cli(["bin"]);
+}
+
+#[test]
+#[should_panic(expected = "Tried to unwrap argument that failed to parse")]
+fn plain_without_default_parse_failure_panics() {
+    let _ = PlainNoDefaultArgs::parse_cli(["bin", "--num", "bad"]);
+}
+
+#[test]
+fn plain_without_default_parse_success_is_value() {
+    let (args, _) =
+        PlainNoDefaultArgs::parse_cli(["bin", "--num", "5"]).expect("failed to parse plain args");
+    assert_eq!(args.num, 5);
+}
+
+#[test]
+fn plain_default_missing_uses_default() {
+    let (args, _) = PlainDefaultArgs::parse_cli(["bin"]).expect("failed to parse plain args");
+    assert_eq!(args.num, 7);
+}
+
+#[test]
+fn plain_default_parse_success_overrides_default() {
+    let (args, _) =
+        PlainDefaultArgs::parse_cli(["bin", "--num", "9"]).expect("failed to parse plain args");
+    assert_eq!(args.num, 9);
+}
+
+#[test]
+#[should_panic(expected = "Tried to unwrap argument that failed to parse")]
+fn plain_default_parse_failure_panics() {
+    let _ = PlainDefaultArgs::parse_cli(["bin", "--num", "bad"]);
 }

--- a/src/test/macros.rs
+++ b/src/test/macros.rs
@@ -30,11 +30,11 @@ sarge! {
 }
 
 sarge! {
-    > "Derived test args"
+    /// Derived test args
     #[derive(Debug, PartialEq, Eq)]
     DerivedArgs,
 
-    > "Derived test flag"
+    /// Derived test flag
     derived_flag: bool,
 }
 
@@ -95,7 +95,7 @@ fn doc_comments_are_used_for_help() {
 
 #[cfg(feature = "help")]
 #[test]
-fn angle_docs_are_used_for_help() {
+fn derived_args_docs_are_used_for_help() {
     let s = DerivedArgs::help();
     assert!(s.contains("Derived test args"));
     assert!(s.contains("Derived test flag"));
@@ -103,13 +103,13 @@ fn angle_docs_are_used_for_help() {
 
 #[cfg(feature = "help")]
 sarge! {
-    > "Docs from >"
-    /// Docs from ///
+    /// Docs line 1
+    /// Docs line 2
     #[allow(dead_code)]
     MixedDocArgs,
 
-    > "Field docs from >"
-    /// Field docs from ///
+    /// Field docs line 1
+    /// Field docs line 2
     mixed_flag: bool,
 }
 
@@ -117,10 +117,10 @@ sarge! {
 #[test]
 fn mixed_docs_are_used_for_help() {
     let s = MixedDocArgs::help();
-    assert!(s.contains("Docs from >"));
-    assert!(s.contains("Docs from ///"));
-    assert!(s.contains("Field docs from >"));
-    assert!(s.contains("Field docs from ///"));
+    assert!(s.contains("Docs line 1"));
+    assert!(s.contains("Docs line 2"));
+    assert!(s.contains("Field docs line 1"));
+    assert!(s.contains("Field docs line 2"));
 }
 
 mod polluted_ok_import {

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,6 +34,12 @@ pub trait ArgumentType: Sized {
     /// Whether or not this type consumes any arguments.
     const CONSUMES: bool = true;
 
+    /// Whether this argument can be specified multiple times and should
+    /// accumulate values instead of overwriting.
+    ///
+    /// This is primarily used for `Vec<T>`, so `-H a -H b` becomes `["a", "b"]`.
+    const REPEATABLE: bool = false;
+
     /// Perform parsing on the value.
     ///
     /// If the argument doesn't take any input, `val` is None.
@@ -105,6 +111,8 @@ impl ArgumentType for bool {
 
 impl<T: ArgumentType> ArgumentType for Vec<T> {
     type Error = T::Error;
+
+    const REPEATABLE: bool = true;
 
     fn from_value(val: Option<&str>) -> ArgResult<Self> {
         let bits = val?.split(',');


### PR DESCRIPTION
feat(sarge): add convenience defaults for String and Vec

- Add support for more ergonomic default value specifications in macro definitions: String defaults can now be specified as string literals directly Vec<String> defaults can be written using vec["a", "b"] syntax

- This change introduces a new trait __SargeDefaultExpr and helper function __sarge_default_expr to handle expression-based defaults while avoiding type inference issues.

- Also modify macro expansion to use .get_raw() for accessing argument values, which bypasses the type's ArgumentType::default_value() to allow macro-provided defaults to take precedence.

- Update tests and documentation to reflect these changes.

---

feat(help): add support for mixed doc comments in help generation

- Introduce handling for both > and /// style doc comments in help text generation for sarge!-derived structs. Add tests to ensure both forms are included in generated help output when the "help" feature is enabled.

---

#### repeatable

```rust
#[test]
fn repeatable_list_type_accumulates_values() {
    let mut parser = ArgumentReader::new();
    let list = parser.add(tag::short('H'));

    let args = ["test", "-H", "xx", "-H", "xxx", "-H", "sadfh,sjffk"];

    let args = parser.parse_cli(args).expect("failed to parse arguments");

    assert_eq!(
        list.get(&args),
        Some(Ok(vec![
            "xx".to_string(),
            "xxx".to_string(),
            "sadfh".to_string(),
            "sjffk".to_string(),
        ]))
    );
}

#[test]
fn repeatable_list_type_cli_overrides_env() {
    let mut parser = ArgumentReader::new();
    let list = parser.add(tag::long("list").env("LIST"));

    let env = [("LIST", "env1,env2")];
    let cli = ["test", "--list", "cli1", "--list", "cli2"];

    let args = parser
        .parse_provided(cli, env)
        .expect("failed to parse provided arguments");

    assert_eq!(
        list.get(&args),
        Some(Ok(vec!["cli1".to_string(), "cli2".to_string()]))
    );
}
```

### doc `///` impl

```rust
#[cfg(feature = "help")]
sarge! {
    > "Docs from >"
    /// Docs from ///
    #[allow(dead_code)]
    MixedDocArgs,

    > "Field docs from >"
    /// Field docs from ///
    mixed_flag: bool,
}


#[cfg(feature = "help")]
#[test]
fn mixed_docs_are_used_for_help() {
    let s = MixedDocArgs::help();
    assert!(s.contains("Docs from >"));
    assert!(s.contains("Docs from ///"));
    assert!(s.contains("Field docs from >"));
    assert!(s.contains("Field docs from ///"));
}
```

And maybe the `>` doc identifier should be removed, if you accept it, I will post the next PR for alternative the `>` to `\\\` completely.